### PR TITLE
Clarifying `WebsocketBundle` constructor usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or, if you prefer, you can register the endpoint before the running stage:
 
 ```java
 public void initialize(Bootstrap<Configuration> bootstrap) {
-    websocketBundle = new WebsocketBundle();        
+    WebsocketBundle websocketBundle = new WebsocketBundle(null, new ArrayList<>(), new ArrayList<>());        
     bootstrap.addBundle(websocketBundle);
 }
 


### PR DESCRIPTION
There is no default constructor `WebsocketBundle` as specified in the readme, so this PR is just clarifying how to set up an initially empty `WebsocketBundle`.