### PR TITLE
Clarify `WebsocketBundle` constructor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or, if you prefer, you can register the endpoint before the running stage:
 
 ```java
 public void initialize(Bootstrap<Configuration> bootstrap) {
-    websocketBundle = new WebsocketBundle();        
+    websocketBundle = new WebsocketBundle(null, new ArrayList<>(), new ArrayList<>());
     bootstrap.addBundle(websocketBundle);
 }
 


### PR DESCRIPTION
`WebsocketBundle` has no default constructor  as specified in the README, so this PR is just clarifying how to set up an initially empty `WebsocketBundle`.